### PR TITLE
Update go.sum before building proxygen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.17"
+          go-version: "1.18"
       - name: Check
         run: make check test

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ grpc-mock:
 .PHONY: proxy
 proxy:
 	printf $(COLOR) "Generate proxy code..."
-	(cd ./cmd/proxygenerator && go run ./)
+	(cd ./cmd/proxygenerator && go mod tidy && go run ./)
 
 goimports:
 	printf $(COLOR) "Run goimports..."
@@ -112,7 +112,7 @@ test:
 
 generatorcheck:
 	printf $(COLOR) "Check generated code is not stale..."
-	(cd ./cmd/proxygenerator && go run ./ -verifyOnly)
+	(cd ./cmd/proxygenerator && go mod tidy && go run ./ -verifyOnly)
 
 check: generatorcheck
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Run `go mod tidy` before running the proxy codegen

<!-- Tell your future self why have you made these changes -->
**Why?**
The unpinned versions (e.g. we depend on the latest version of google.golang.org/genproto) change frequently and if the go.sum isn't updated, builds will fail.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Running locally

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

