### PR TITLE
Pin 3rd party actions to a full-length commit SHA.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     steps:
       - name: Print build information
         run: "echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}"
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version: "1.18"
       - name: Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Print build information
-        run: "echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}"
+        run: "echo head_ref: $GITHUB_HEAD_REF, ref: $GITHUB_REF"
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -21,5 +21,5 @@ jobs:
       image: returntocorp/semgrep
     if: (github.actor != 'dependabot[bot]')
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - run: semgrep ci

--- a/.github/workflows/update-proto.yml
+++ b/.github/workflows/update-proto.yml
@@ -24,16 +24,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           submodules: true
           persist-credentials: false
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version: 1.18
 
-      - uses: arduino/setup-protoc@v1
+      - uses: arduino/setup-protoc@e58d94cc5c94a8e49c8b747feac4b1c17f199561 # v2.0.0
         with:
           version: '3.x'
 


### PR DESCRIPTION
## What was changed
Used [ghat](https://github.com/JamesWoolfenden/ghat) locally to fetch the commit SHA of the latest version of all actions in all workflows.

## Why?
Github's security hardening recommendations for actions include [pinning actions to a full length commit SHA](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

## How did you test it?
Looked at the workflow logs on this PR.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
The pinned commit SHAs here seem to be version jumps, so these actions might not work as intended.
