### PR TITLE
Mitigate injection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Print build information
-        run: "echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}"
+        run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF"'
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
**What changed?**
Replace interpolated github context variables with default variables used more defensively. 

**Why?**
This mitigates an attacker naming a branch a command that could run in our runner's context.

**How did you test it?**
Ran in my own fork and it was fine in my workflow.

**Potential risks**
Somehow not printing the build info in the workflow output.

