### PR TITLE
Fix update-proto workflow

### DIFF
--- a/.github/workflows/update-proto.yml
+++ b/.github/workflows/update-proto.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.20
+          go-version: "1.20"
 
       - uses: arduino/setup-protoc@v1
         with:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Fix Go setup step in update-proto workflow.

<!-- Tell your future self why have you made these changes -->
**Why?**

YAML interprets `1.20` as `1.2` and this workflow broke.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

I actually didn't. But we know this works from https://github.com/temporalio/api-go/blob/224b196919eabc405c43051c9f280afb6457e5ba/.github/workflows/ci.yml#L17

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

Workflow still broken after this.