### PR TITLE
Handle wrapped ServiceErrors in Convert

### DIFF
--- a/serviceerror/convert.go
+++ b/serviceerror/convert.go
@@ -43,7 +43,7 @@ func ToStatus(err error) *status.Status {
 		return svcerr.Status()
 	}
 	// err does not implement ServiceError directly, but check if it wraps it.
-	// This path does more copying so prefer to return a ServiceError directly if possible.
+	// This path does more allocation so prefer to return a ServiceError directly if possible.
 	var svcerr ServiceError
 	if errors.As(err, &svcerr) {
 		s := svcerr.Status().Proto()

--- a/serviceerror/convert.go
+++ b/serviceerror/convert.go
@@ -42,6 +42,14 @@ func ToStatus(err error) *status.Status {
 	if svcerr, ok := err.(ServiceError); ok {
 		return svcerr.Status()
 	}
+	// err does not implement ServiceError directly, but check if it wraps it.
+	// This path does more copying so prefer to return a ServiceError directly if possible.
+	var svcerr ServiceError
+	if errors.As(err, &svcerr) {
+		s := svcerr.Status().Proto()
+		s.Message = err.Error() // don't lose the wrapped message
+		return status.FromProto(s)
+	}
 
 	// Special case for context.DeadlineExceeded and context.Canceled because they can happen in unpredictable places.
 	if errors.Is(err, context.DeadlineExceeded) {

--- a/serviceerror/convert_test.go
+++ b/serviceerror/convert_test.go
@@ -32,6 +32,7 @@ import (
 	rpc "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 
@@ -106,8 +107,7 @@ func TestFromWrapped(t *testing.T) {
 	s := serviceerror.ToStatus(wrapped)
 	require.Equal(t, codes.PermissionDenied, s.Code())
 	require.Equal(t, "wrapped error: x is not allowed", s.Message())
-	require.Equal(t,
+	require.True(t, proto.Equal(
 		&errordetails.PermissionDeniedFailure{Reason: "arbitrary reason"},
-		s.Details()[0],
-	)
+		s.Details()[0].(*errordetails.PermissionDeniedFailure)))
 }

--- a/serviceerror/convert_test.go
+++ b/serviceerror/convert_test.go
@@ -24,6 +24,7 @@ package serviceerror_test
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -94,4 +95,19 @@ func TestToStatus_NotServiceError(t *testing.T) {
 	require.Equal(t, codes.Unknown, st1.Code())
 	require.Equal(t, "some error", st1.Message())
 	require.Len(t, st1.Details(), 0)
+}
+
+func TestFromWrapped(t *testing.T) {
+	err := &serviceerror.PermissionDenied{
+		Message: "x is not allowed",
+		Reason:  "arbitrary reason",
+	}
+	wrapped := fmt.Errorf("wrapped error: %w", err)
+	s := serviceerror.ToStatus(wrapped)
+	require.Equal(t, codes.PermissionDenied, s.Code())
+	require.Equal(t, "wrapped error: x is not allowed", s.Message())
+	require.Equal(t,
+		&errordetails.PermissionDeniedFailure{Reason: "arbitrary reason"},
+		s.Details()[0],
+	)
 }


### PR DESCRIPTION
**What changed?**
Make `Convert` handle wrapped `ServiceError`s

**Why?**
We shouldn't lose any more specific error info (i.e. grpc code) if it's present at all in the error.

**How did you test it?**
unit test

**Potential risks**
This code path is a little more expensive, if we end up using it a lot of the time that's a slight waste.