### PR TITLE
Retract version 1.26.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,3 +24,7 @@ require (
 	google.golang.org/genproto v0.0.0-20231127180814-3a041ad873d4 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+retract (
+    v1.26.1 // Published prematurely
+)


### PR DESCRIPTION
**What changed?**
I've marked version 1.26.1 as [retracted](https://go.dev/ref/mod#go-mod-file-retract) so that `go get -u` will not longer upgrade to it. It will still be available if you manually specify it, meaning our downstream repos require no changes.

**Why?**
This was released before we were entirely ready and it caused some user development workflows to break

**How did you test it?**
N/A

**Potential risks**

