### PR TITLE
Preemptively retract v1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,4 +27,5 @@ require (
 
 retract (
     v1.26.1 // Published prematurely
+    v1.26.2 // Contains retractions only.
 )


### PR DESCRIPTION
We need to retract `v1.26.1`, to do that we need to publish `v1.26.2` to make Go tooling aware of the retraction. We also then need to retract the version published to make the retraction `v1.26.2` this is valid.

```
A version containing retractions may retract itself. If the highest release or pre-release version of a module retracts itself, the @latest query resolves to a lower version after retracted versions are excluded.
```


https://go.dev/ref/mod#go-mod-file-retract

