### PR TITLE
allow git submodule update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ $(PROTO_OUT):
 ##### git submodule for proto files #####
 update-proto-submodule:
 	printf $(COLOR) "Update proto-submodule..."
-	git submodule update --init --force --remote $(PROTO_ROOT)
+	git -c protocol.file.allow=always submodule update --init --force --remote $(PROTO_ROOT)
 
 ##### Compile proto files for go #####
 grpc: go-grpc copy-helpers


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

It enables file-based submodule updates, regardless of the user-defined setting.

The idea for the fix was found here: https://bugs.launchpad.net/ubuntu/+source/git/+bug/1993586/comments/3

There is an option to set this globally, but that's undesirable. 

<!-- Tell your future self why have you made these changes -->
**Why?**

Without this, it fails for me with:
```
fatal: transport 'file' not allowed
fatal: Unable to fetch in submodule path 'proto/api'
```

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Ran `make proto` locally. Only succeeds with the change.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

I wouldn't expect older git versions to break but to ignore the config.
