### PR TITLE
ignore .go-helpers-installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .gobincache
+.go-helpers-installed


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Ignores the file `.go-helpers-installed` from git.

<!-- Tell your future self why have you made these changes -->
**Why?**

The file seems to be created as part of the Make target `go-grpc`:
```
go-grpc: clean .go-helpers-installed $(PROTO_OUT)
```

But gets in the way when switching branches.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

`git status` doesn't show the file anymore.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

N/A