### PR TITLE
Fix marshalling of shorthand maps

### DIFF
--- a/internal/temporalcommonv1/payload_json_test.go
+++ b/internal/temporalcommonv1/payload_json_test.go
@@ -82,6 +82,16 @@ var tests = []struct {
 			},
 		},
 	},
+}, {
+	name:          "json/plain with empty object",
+	longformJSON:  `{"metadata":{"encoding":"anNvbi9wbGFpbg=="},"data":"eyJncmVldGluZyI6e319"}`,
+	shorthandJSON: `{"greeting": {}}`,
+	pb: &common.Payload{
+		Metadata: map[string][]byte{
+			"encoding": []byte("json/plain"),
+		},
+		Data: []byte(`{"greeting":{}}`),
+	},
 }}
 
 func TestMaybeMarshal_ShorthandEnabled(t *testing.T) {
@@ -94,7 +104,7 @@ func TestMaybeMarshal_ShorthandEnabled(t *testing.T) {
 			}
 			got, err := opts.Marshal(tt.pb)
 			require.NoError(t, err)
-			t.Logf("%s", string(got))
+			t.Logf("Marshalled to %s", string(got))
 			require.JSONEq(t, tt.shorthandJSON, string(got))
 		})
 	}
@@ -106,7 +116,7 @@ func TestMaybeMarshal_ShorthandDisabled(t *testing.T) {
 			var opts temporalproto.CustomJSONMarshalOptions
 			got, err := opts.Marshal(tt.pb)
 			require.NoError(t, err)
-			t.Logf("%s", string(got))
+			t.Logf("Marshalled to %s", string(got))
 			require.JSONEq(t, tt.longformJSON, string(got))
 		})
 	}

--- a/internal/temporalcommonv1/payload_json_test.go
+++ b/internal/temporalcommonv1/payload_json_test.go
@@ -92,6 +92,16 @@ var tests = []struct {
 		},
 		Data: []byte(`{"greeting":{}}`),
 	},
+}, {
+	name:          "json/plain with nested object",
+	longformJSON:  `{"metadata":{"encoding":"anNvbi9wbGFpbg=="},"data":"eyJncmVldGluZyI6eyJuYW1lIjp7fX19"}`,
+	shorthandJSON: `{"greeting": {"name": {}}}`,
+	pb: &common.Payload{
+		Metadata: map[string][]byte{
+			"encoding": []byte("json/plain"),
+		},
+		Data: []byte(`{"greeting":{"name":{}}}`),
+	},
 }}
 
 func TestMaybeMarshal_ShorthandEnabled(t *testing.T) {


### PR DESCRIPTION
**What changed?**

1. Map values may not be singular items but full values
2. Empty maps should be marshalled as `{}`, not `null`

This fixes temporalio/api#349

**Why?**

Empty maps should always have been marshalled as empty objects, this was a bug in our code. While here I realized a deeper bug, where maps would only support simple values (strings, numbers, etc) but not embedded maps, lists, etc.

**How did you test it?**

New unit test

**Potential risks**

None
