### PR TITLE
Only pass action if commit fails, fail if push fails

### DIFF
--- a/.github/workflows/update-proto.yml
+++ b/.github/workflows/update-proto.yml
@@ -49,4 +49,9 @@ jobs:
         run: |
           git remote set-url origin https://x-access-token:${{ secrets.COMMANDER_DATA_TOKEN }}@github.com/${{ github.repository }}
           git add .
-          git commit -m "${{ github.event.inputs.commit_message }}" && git push || echo "No changes to commit"
+          git commit -m "${{ github.event.inputs.commit_message }}"
+          if [ $? -eq 0 ]; then
+            git push
+          else
+            echo "No changes to commit"
+          fi


### PR DESCRIPTION
**What changed?**

See description

**Why?**

Actions should have been failing due to lack of permissions to push to master.

**How did you test it?**

I ran the changes in a shell script that confirms the behavior.