### PR TITLE
Port fix for CVE-2024-24786

### DIFF
--- a/internal/protojson/json/decode.go
+++ b/internal/protojson/json/decode.go
@@ -121,7 +121,7 @@ func (d *Decoder) Read() (Token, error) {
 
 	case ObjectClose:
 		if len(d.openStack) == 0 ||
-			d.lastToken.kind == comma ||
+			d.lastToken.kind&(Name|comma) != 0 ||
 			d.openStack[len(d.openStack)-1] != ObjectOpen {
 			return Token{}, d.newSyntaxError(tok.pos, unexpectedFmt, tok.RawString())
 		}

--- a/internal/protojson/json/decode_test.go
+++ b/internal/protojson/json/decode_test.go
@@ -1192,6 +1192,21 @@ func TestDecoder(t *testing.T) {
 			},
 		},
 		{
+			in: `{""`,
+			want: []R{
+				{V: ObjectOpen},
+				{E: errEOF},
+			},
+		},
+		{
+			in: `{"":`,
+			want: []R{
+				{V: ObjectOpen},
+				{V: Name{""}},
+				{E: errEOF},
+			},
+		},
+		{
 			in: `{"34":"89",}`,
 			want: []R{
 				{V: ObjectOpen},

--- a/internal/protojson/json_unmarshal_test.go
+++ b/internal/protojson/json_unmarshal_test.go
@@ -2503,6 +2503,23 @@ func TestUnmarshal(t *testing.T) {
 		inputText:    `{"foo":{"bar":[{"baz":[{}]]}}`,
 		umo:          protojson.UnmarshalOptions{RecursionLimit: 5, DiscardUnknown: true},
 		wantErr:      "exceeded max recursion depth",
+	}, {
+		desc:         "Object missing value: no DiscardUnknown",
+		inputMessage: &testpb.TestAllTypes{},
+		inputText:    `{"":}`,
+		umo:          protojson.UnmarshalOptions{RecursionLimit: 5, DiscardUnknown: false},
+		wantErr:      `(line 1:2): unknown field ""`,
+	}, {
+		desc:         "Object missing value: DiscardUnknown",
+		inputMessage: &testpb.TestAllTypes{},
+		inputText:    `{"":}`,
+		umo:          protojson.UnmarshalOptions{RecursionLimit: 5, DiscardUnknown: true},
+		wantErr:      `(line 1:5): unexpected token`,
+	}, {
+		desc:         "Object missing value: Any",
+		inputMessage: &anypb.Any{},
+		inputText:    `{"":}`,
+		wantErr:      `(line 1:5): unexpected token`,
 	}}
 
 	for _, tt := range tests {

--- a/internal/protojson/well_known_types.go
+++ b/internal/protojson/well_known_types.go
@@ -323,6 +323,10 @@ func (d decoder) skipJSONValue() error {
 			if open > d.opts.RecursionLimit {
 				return errors.New("exceeded max recursion depth")
 			}
+		case json.EOF:
+			// This can only happen if there's a bug in Decoder.Read.
+			// Avoid an infinite loop if this does happen.
+			return errors.New("unexpected EOF")
 		}
 		if open == 0 {
 			return nil


### PR DESCRIPTION
Official description from NVD: https://nvd.nist.gov/vuln/detail/CVE-2024-24786

From the official commit:

> encoding/protojson, internal/encoding/json: handle missing object values
>
> In internal/encoding/json, report an error when encountering a }
> when we are expecting an object field value. For example, the input
> `{"":}` now correctly results in an error at the closing } token.
>
> In encoding/protojson, check for an unexpected EOF token in
> skipJSONValue. This is redundant with the check in internal/encoding/json,
> but adds a bit more defense against any other similar bugs that
> might exist.
>
> Fixes CVE-2024-24786
>
> Change-Id: I03d52512acb5091c8549e31ca74541d57e56c99d
> Reviewed-on: https://go-review.googlesource.com/c/protobuf/+/569356
> TryBot-Bypass: Damien Neil <dneil@google.com>
> Reviewed-by: Roland Shoemaker <roland@golang.org>
> Commit-Queue: Damien Neil <dneil@google.com>

