### PR TITLE
Fix shorthand encoding of Payloads

### DIFF
--- a/common/v1/payload_json.go
+++ b/common/v1/payload_json.go
@@ -262,14 +262,11 @@ func (p *Payloads) MaybeMarshalProtoJSON(meta map[string]interface{}, enc *json.
 		return false, nil
 	}
 
-	if len(p.Payloads) == 0 {
-		enc.WriteNull()
-		return true, nil
-	}
-	// We only support marshalling to shorthand if all payloads are handled or
-	// there are no payloads
 	enc.StartArray()
 	defer enc.EndArray()
+
+	// We only support marshalling to shorthand if all payloads are handled or
+	// there are no payloads
 	for i := 0; i < len(p.Payloads); i++ {
 		// If any are not handled or there is an error, return
 		handled, val, err := p.Payloads[i].toJSONShorthand()

--- a/common/v1/payload_json.go
+++ b/common/v1/payload_json.go
@@ -262,17 +262,21 @@ func (p *Payloads) MaybeMarshalProtoJSON(meta map[string]interface{}, enc *json.
 		return false, nil
 	}
 
-	enc.StartArray()
-	defer enc.EndArray()
-
 	// We only support marshalling to shorthand if all payloads are handled or
-	// there are no payloads
-	for i := 0; i < len(p.Payloads); i++ {
-		// If any are not handled or there is an error, return
-		handled, val, err := p.Payloads[i].toJSONShorthand()
+	// there are no payloads, so check if all can be handled first.
+	vals := make([]any, len(p.Payloads))
+	for i, payload := range p.Payloads {
+		handled, val, err := payload.toJSONShorthand()
 		if !handled || err != nil {
 			return handled, err
 		}
+		vals[i] = val
+	}
+
+	enc.StartArray()
+	defer enc.EndArray()
+
+	for _, val := range vals {
 		if err := marshal(enc, val); err != nil {
 			return true, err
 		}

--- a/common/v1/payload_json.go
+++ b/common/v1/payload_json.go
@@ -263,10 +263,11 @@ func (p *Payloads) MaybeMarshalProtoJSON(meta map[string]interface{}, enc *json.
 	}
 
 	if len(p.Payloads) == 0 {
+		enc.WriteNull()
 		return true, nil
 	}
 	// We only support marshalling to shorthand if all payloads are handled or
-	// there  are no payloads
+	// there are no payloads
 	enc.StartArray()
 	defer enc.EndArray()
 	for i := 0; i < len(p.Payloads); i++ {
@@ -300,8 +301,12 @@ func (p *Payloads) MaybeUnmarshalProtoJSON(meta map[string]interface{}, dec *jso
 		return true, err
 	}
 
-	// If this isn't an array, then it's not shorthand
-	if tok.Kind() != json.ArrayOpen {
+	if tok.Kind() == json.Null {
+		// Null is accepted as empty list
+		_, _ = dec.Read()
+		return true, nil
+	} else if tok.Kind() != json.ArrayOpen {
+		// If this isn't an array, then it's not shorthand
 		return false, nil
 	}
 	_, _ = dec.Read()

--- a/common/v1/payload_json.go
+++ b/common/v1/payload_json.go
@@ -266,18 +266,17 @@ func (p *Payloads) MaybeMarshalProtoJSON(meta map[string]interface{}, enc *json.
 	// there are no payloads, so check if all can be handled first.
 	vals := make([]any, len(p.Payloads))
 	for i, payload := range p.Payloads {
-		handled, val, err := payload.toJSONShorthand()
+		handled, vals[i], err = payload.toJSONShorthand()
 		if !handled || err != nil {
 			return handled, err
 		}
-		vals[i] = val
 	}
 
 	enc.StartArray()
 	defer enc.EndArray()
 
 	for _, val := range vals {
-		if err := marshal(enc, val); err != nil {
+		if err = marshal(enc, val); err != nil {
 			return true, err
 		}
 	}

--- a/internal/temporalcommonv1/payload_json.go
+++ b/internal/temporalcommonv1/payload_json.go
@@ -262,14 +262,11 @@ func (p *Payloads) MaybeMarshalProtoJSON(meta map[string]interface{}, enc *json.
 		return false, nil
 	}
 
-	if len(p.Payloads) == 0 {
-		enc.WriteNull()
-		return true, nil
-	}
-	// We only support marshalling to shorthand if all payloads are handled or
-	// there are no payloads
 	enc.StartArray()
 	defer enc.EndArray()
+
+	// We only support marshalling to shorthand if all payloads are handled or
+	// there are no payloads
 	for i := 0; i < len(p.Payloads); i++ {
 		// If any are not handled or there is an error, return
 		handled, val, err := p.Payloads[i].toJSONShorthand()

--- a/internal/temporalcommonv1/payload_json.go
+++ b/internal/temporalcommonv1/payload_json.go
@@ -262,17 +262,21 @@ func (p *Payloads) MaybeMarshalProtoJSON(meta map[string]interface{}, enc *json.
 		return false, nil
 	}
 
-	enc.StartArray()
-	defer enc.EndArray()
-
 	// We only support marshalling to shorthand if all payloads are handled or
-	// there are no payloads
-	for i := 0; i < len(p.Payloads); i++ {
-		// If any are not handled or there is an error, return
-		handled, val, err := p.Payloads[i].toJSONShorthand()
+	// there are no payloads, so check if all can be handled first.
+	vals := make([]any, len(p.Payloads))
+	for i, payload := range p.Payloads {
+		handled, val, err := payload.toJSONShorthand()
 		if !handled || err != nil {
 			return handled, err
 		}
+		vals[i] = val
+	}
+
+	enc.StartArray()
+	defer enc.EndArray()
+
+	for _, val := range vals {
 		if err := marshal(enc, val); err != nil {
 			return true, err
 		}

--- a/internal/temporalcommonv1/payload_json.go
+++ b/internal/temporalcommonv1/payload_json.go
@@ -263,10 +263,11 @@ func (p *Payloads) MaybeMarshalProtoJSON(meta map[string]interface{}, enc *json.
 	}
 
 	if len(p.Payloads) == 0 {
+		enc.WriteNull()
 		return true, nil
 	}
 	// We only support marshalling to shorthand if all payloads are handled or
-	// there  are no payloads
+	// there are no payloads
 	enc.StartArray()
 	defer enc.EndArray()
 	for i := 0; i < len(p.Payloads); i++ {
@@ -300,8 +301,12 @@ func (p *Payloads) MaybeUnmarshalProtoJSON(meta map[string]interface{}, dec *jso
 		return true, err
 	}
 
-	// If this isn't an array, then it's not shorthand
-	if tok.Kind() != json.ArrayOpen {
+	if tok.Kind() == json.Null {
+		// Null is accepted as empty list
+		_, _ = dec.Read()
+		return true, nil
+	} else if tok.Kind() != json.ArrayOpen {
+		// If this isn't an array, then it's not shorthand
 		return false, nil
 	}
 	_, _ = dec.Read()

--- a/internal/temporalcommonv1/payload_json.go
+++ b/internal/temporalcommonv1/payload_json.go
@@ -266,18 +266,17 @@ func (p *Payloads) MaybeMarshalProtoJSON(meta map[string]interface{}, enc *json.
 	// there are no payloads, so check if all can be handled first.
 	vals := make([]any, len(p.Payloads))
 	for i, payload := range p.Payloads {
-		handled, val, err := payload.toJSONShorthand()
+		handled, vals[i], err = payload.toJSONShorthand()
 		if !handled || err != nil {
 			return handled, err
 		}
-		vals[i] = val
 	}
 
 	enc.StartArray()
 	defer enc.EndArray()
 
 	for _, val := range vals {
-		if err := marshal(enc, val); err != nil {
+		if err = marshal(enc, val); err != nil {
 			return true, err
 		}
 	}

--- a/internal/temporalcommonv1/payload_json_test.go
+++ b/internal/temporalcommonv1/payload_json_test.go
@@ -102,6 +102,30 @@ var tests = []struct {
 		},
 		Data: []byte(`{"greeting":{"name":{}}}`),
 	},
+}, {
+	name:          "empty payloads",
+	longformJSON:  `{}`,
+	shorthandJSON: `null`,
+	pb:            &common.Payloads{},
+}, {
+	name:          "empty payloads with non-nil slice",
+	longformJSON:  `{}`,
+	shorthandJSON: `null`,
+	pb:            &common.Payloads{Payloads: []*common.Payload{}},
+}, {
+	name:          "payloads with two items",
+	longformJSON:  `{"payloads":[{"data":"InN0cmluZyB2YWx1ZSI=","metadata":{"encoding":"anNvbi9wbGFpbg=="}},{"data":"MzI0Mw==","metadata":{"encoding":"anNvbi9wbGFpbg=="}}]}`,
+	shorthandJSON: `["string value", 3243]`,
+	pb: &common.Payloads{Payloads: []*common.Payload{
+		&common.Payload{
+			Metadata: map[string][]byte{"encoding": []byte("json/plain")},
+			Data:     []byte(`"string value"`),
+		},
+		&common.Payload{
+			Metadata: map[string][]byte{"encoding": []byte("json/plain")},
+			Data:     []byte(`3243`),
+		},
+	}},
 }}
 
 func TestMaybeMarshal_ShorthandEnabled(t *testing.T) {

--- a/internal/temporalcommonv1/payload_json_test.go
+++ b/internal/temporalcommonv1/payload_json_test.go
@@ -105,12 +105,12 @@ var tests = []struct {
 }, {
 	name:          "empty payloads",
 	longformJSON:  `{}`,
-	shorthandJSON: `null`,
+	shorthandJSON: `[]`,
 	pb:            &common.Payloads{},
 }, {
 	name:          "empty payloads with non-nil slice",
 	longformJSON:  `{}`,
-	shorthandJSON: `null`,
+	shorthandJSON: `[]`,
 	pb:            &common.Payloads{Payloads: []*common.Payload{}},
 }, {
 	name:          "payloads with two items",
@@ -182,4 +182,16 @@ func TestMaybeUnmarshal_Longform(t *testing.T) {
 			require.True(t, proto.Equal(tt.pb, out))
 		})
 	}
+}
+
+func TestMaybeUnmarshal_Payloads_AcceptsNull(t *testing.T) {
+	var out common.Payloads
+	opts := temporalproto.CustomJSONUnmarshalOptions{
+		Metadata: map[string]interface{}{
+			common.EnablePayloadShorthandMetadataKey: true,
+		},
+	}
+	err := opts.Unmarshal([]byte("null"), &out)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(out.Payloads))
 }


### PR DESCRIPTION
**What changed?**
Marshal/unmarshal empty `Payloads` as `[]` in shorthand encoding (also accept `null` on unmarshal).
Handle the case where one or more `Payload` within `Payloads` can't be encoded as shorthand.

**Why?**
These cases were producing invalid json.

**How did you test it?**
unit tests