### PR TITLE
Clean cloud folder in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,3 +146,5 @@ clean:
 	printf $(COLOR) "Deleting generated go files..."
 	# Delete all directories with *.pb.go and *.mock.go files from $(PROTO_OUT)
 	find $(PROTO_OUT) \( -name "*.pb.go" -o -name "*.mock.go" -o -name "*.go-helpers.go" \) | xargs -I{} dirname {} | egrep -v 'testprotos' | sort -u | xargs rm -rf
+	# Delete entire cloud dir
+	rm -rf cloud


### PR DESCRIPTION
**What changed?**

In preparation for https://github.com/temporalio/api/pull/378, the `clean` target needs to work with a subdir like `cloud`, so since we have no non-generated code in `cloud`, we just delete the entire directory on `clean`