### PR TITLE
Fix shorthand payload marshaling when `null` is present

### DIFF
--- a/common/v1/payload_json.go
+++ b/common/v1/payload_json.go
@@ -185,9 +185,10 @@ func marshalValue(enc *json.Encoder, vv reflect.Value) error {
 		}
 	case reflect.Interface, reflect.Pointer:
 		if vv.IsNil() {
-			return nil
+			enc.WriteNull()
+		} else {
+			marshalValue(enc, vv.Elem())
 		}
-		marshalValue(enc, vv.Elem())
 	case reflect.Struct:
 		marshalStruct(enc, vv)
 	case reflect.Map:

--- a/internal/temporalcommonv1/payload_json.go
+++ b/internal/temporalcommonv1/payload_json.go
@@ -185,9 +185,10 @@ func marshalValue(enc *json.Encoder, vv reflect.Value) error {
 		}
 	case reflect.Interface, reflect.Pointer:
 		if vv.IsNil() {
-			return nil
+			enc.WriteNull()
+		} else {
+			marshalValue(enc, vv.Elem())
 		}
-		marshalValue(enc, vv.Elem())
 	case reflect.Struct:
 		marshalStruct(enc, vv)
 	case reflect.Map:

--- a/internal/temporalcommonv1/payload_json_test.go
+++ b/internal/temporalcommonv1/payload_json_test.go
@@ -104,6 +104,16 @@ var tests = []struct {
 		Data: []byte(`{"greeting":{"name":{}}}`),
 	},
 }, {
+	name:          "json/plain with null",
+	longformJSON:  `{"metadata":{"encoding":"anNvbi9wbGFpbg=="},"data":"eyJncmVldGluZyI6bnVsbH0="}`,
+	shorthandJSON: `{"greeting": null}`,
+	pb: &common.Payload{
+		Metadata: map[string][]byte{
+			"encoding": []byte("json/plain"),
+		},
+		Data: []byte(`{"greeting":null}`),
+	},
+}, {
 	name:          "empty payloads",
 	longformJSON:  `{}`,
 	shorthandJSON: `[]`,

--- a/internal/temporalcommonv1/payload_json_test.go
+++ b/internal/temporalcommonv1/payload_json_test.go
@@ -234,3 +234,22 @@ func TestMaybeMarshal_Payloads_Unhandled(t *testing.T) {
 	require.NoError(t, json.Unmarshal(out, &i), "must unmarshal as valid json")
 	require.Equal(t, '{', rune(out[0]), "should encode as long-form, not shorthand")
 }
+
+func TestTest(t *testing.T) {
+
+	pb := &common.Payload{
+		Metadata: map[string][]byte{
+			"encoding": []byte("json/plain"),
+		},
+		Data: []byte(`{"greeting":null}`),
+	}
+	opts := temporalproto.CustomJSONMarshalOptions{
+		Metadata: map[string]interface{}{
+			common.EnablePayloadShorthandMetadataKey: true,
+		},
+	}
+	got, err := opts.Marshal(pb)
+	require.NoError(t, err)
+	t.Logf("Marshalled to %s", string(got))
+	require.JSONEq(t, `{"greeting": null}`, string(got))
+}


### PR DESCRIPTION
**What changed?**
I fixed an embarrassing bug in shorthand payload marshaling when `null` is present

**Why?**

Because it was a bug!

**How did you test it?**

I added a new test. I plan to add property-based testing to this shortly, but that will come in a new PR.


**Potential risks**
None
