### PR TITLE
Revert "Change update-proto workflow auth"

### DIFF
--- a/.github/workflows/update-proto.yml
+++ b/.github/workflows/update-proto.yml
@@ -17,8 +17,6 @@ jobs:
   sync:
     name: "Update proto"
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
 
     defaults:
       run:
@@ -26,12 +24,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
           submodules: true
-          persist-credentials: true
+          persist-credentials: false
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v2
         with:
           go-version: "1.20"
 
@@ -42,7 +40,6 @@ jobs:
       - name: Re-build proto
         run: |
           make install update-proto test
-          
       - name: Commit update
         env:
           GIT_AUTHOR_NAME: ${{ github.event.inputs.commit_author }}
@@ -50,7 +47,7 @@ jobs:
           GIT_COMMITTER_NAME: ${{ github.event.inputs.commit_author }}
           GIT_COMMITTER_EMAIL: ${{ github.event.inputs.commit_author_email }}
         run: |
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
+          git remote set-url origin https://x-access-token:${{ secrets.COMMANDER_DATA_TOKEN }}@github.com/${{ github.repository }}
           git add .
           git commit -m "${{ github.event.inputs.commit_message }}"
           if [ $? -eq 0 ]; then


### PR DESCRIPTION
Reverts temporalio/api-go#116

Looks like something broke autoupdate of this repo when a change is merged in https://github.com/temporalio/api repo. This commit is a possible reason for the breakage. So reverting it to see if the updates go through.