### PR TITLE
[GHA] Replace token with CICD app

### DIFF
--- a/.github/workflows/update-proto.yml
+++ b/.github/workflows/update-proto.yml
@@ -17,9 +17,6 @@ on:
         description: "Commit message"
         required: true
 
-permissions:
-  contents: write
-
 jobs:
   sync:
     name: "Update proto"
@@ -30,10 +27,17 @@ jobs:
         shell: bash
 
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
+          private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.generate_token.outputs.token }}
           persist-credentials: true
           ref: ${{ github.event.inputs.branch }}
           submodules: true


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
The Github token cannot bypass required pull request, but the Temporal CICD app can, which I've added to the list of allowed users to bypass it.


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

