### PR TITLE
Bump CI build to go 1.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.20"
+          go-version: "1.23"
       - name: Check
         run: make check test

--- a/cmd/proxygenerator/go.mod
+++ b/cmd/proxygenerator/go.mod
@@ -1,6 +1,6 @@
 module go.temporal.io/api/cmd/proxygenerator
 
-go 1.21
+go 1.23
 
 replace go.temporal.io/api => ../..
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.temporal.io/api
 
-go 1.21
+go 1.23
 
 require (
 	github.com/golang/mock v1.6.0


### PR DESCRIPTION
**What changed?**
- Bumped Go version used for CI + proto builds to 1.23

**Why?**
- Our automated merge builds [began failing](https://github.com/temporalio/api-go/actions/runs/10604768987/job/29392179469)

**How did you test it?**
- Pending

**Potential risks**

