### PR TITLE
Bump Go version for CI builds to 1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.20"
+          go-version: "1.21"
       - name: Check
         run: make check test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: Check
         run: make check test


### PR DESCRIPTION
**What changed?**
- Bumped Go version used for CI builds to 1.21

**Why?**
- Our automated merge builds [began failing](https://github.com/temporalio/api-go/actions/runs/10604768987/job/29392179469)
- [gRPC release 1.66](https://github.com/grpc/grpc-go/tree/v1.66.0?tab=readme-ov-file), which the auto commit updated the package to, supports 1.22 and 1.23.  

**How did you test it?**
- Pending

**Potential risks**

