### PR TITLE
Remove automatic dependency upgrade on proto update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install: grpc-install mockgen-install goimports-install update-proto
 proto: http-api-docs grpc goimports proxy grpc-mock copyright
 
 # Update submodule and compile proto files.
-update-proto: update-proto-submodule proto update-dependencies gomodtidy
+update-proto: update-proto-submodule proto gomodtidy
 ########################################################################
 
 ##### Variables ######


### PR DESCRIPTION
**What changed?**

Previously we automatically updated all dependencies on every proto submodule update GitHub workflow (triggered by merge in `api` repo). This means that we are forcing users to upgrade things like gRPC unnecessarily. This removes that step from the proto submodule update.