### PR TITLE
Add unimplemented gRPC server embeds to mock servers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,9 @@ grpc-mock:
 	mockgen -package operatorservicemock -source operatorservice/v1/service_grpc.pb.go -destination operatorservicemock/v1/service_grpc.pb.mock.go
 	mockgen -package workflowservicemock -source workflowservice/v1/service_grpc.pb.go -destination workflowservicemock/v1/service_grpc.pb.mock.go
 	mockgen -package cloudservicemock -source cloud/cloudservice/v1/service_grpc.pb.go -destination cloud/cloudservicemock/v1/service_grpc.pb.mock.go
+	go run ./cmd/mockgen-fix OperatorService operatorservicemock/v1/service_grpc.pb.mock.go
+	go run ./cmd/mockgen-fix WorkflowService workflowservicemock/v1/service_grpc.pb.mock.go
+	go run ./cmd/mockgen-fix CloudService cloud/cloudservicemock/v1/service_grpc.pb.mock.go
 
 .PHONY: proxy
 proxy:

--- a/cloud/cloudservicemock/v1/service_grpc.pb.mock.go
+++ b/cloud/cloudservicemock/v1/service_grpc.pb.mock.go
@@ -720,9 +720,12 @@ func (mr *MockCloudServiceClientMockRecorder) UpdateUserGroup(ctx, in interface{
 
 // MockCloudServiceServer is a mock of CloudServiceServer interface.
 type MockCloudServiceServer struct {
+	cloudservice.UnimplementedCloudServiceServer
 	ctrl     *gomock.Controller
 	recorder *MockCloudServiceServerMockRecorder
 }
+
+var _ cloudservice.CloudServiceServer = (*MockCloudServiceServer)(nil)
 
 // MockCloudServiceServerMockRecorder is the mock recorder for MockCloudServiceServer.
 type MockCloudServiceServerMockRecorder struct {

--- a/cmd/mockgen-fix/main.go
+++ b/cmd/mockgen-fix/main.go
@@ -1,0 +1,86 @@
+// The MIT License
+//
+// Copyright (c) 2022 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"fmt"
+	"go/format"
+	"log"
+	"os"
+	"strings"
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	// This code fixes the generated mock service server code to properly embed
+	// the necessary unimplemented struct and add the interface assertion
+
+	if len(os.Args) != 3 {
+		return fmt.Errorf("must provide service name and code filename as arguments")
+	}
+	// Read file
+	b, err := os.ReadFile(os.Args[2])
+	if err != nil {
+		return fmt.Errorf("unable to read file: %w", err)
+	}
+	source := string(b)
+	serviceName := os.Args[1]
+
+	// Find the first "Server struct {" location
+	toFind := fmt.Sprintf("Mock%vServer struct {\n", serviceName)
+	structIndex := strings.Index(source, toFind)
+	if structIndex < 0 || strings.LastIndex(source, toFind) != structIndex {
+		return fmt.Errorf("expected single server struct in file")
+	}
+	structIndex += len(toFind)
+
+	// At the first newline we need to embed the unimplemented server
+	source = source[:structIndex] +
+		fmt.Sprintf("\t%v.Unimplemented%vServer\n", strings.ToLower(serviceName), serviceName) +
+		source[structIndex:]
+
+	// After the closing brace, we need to add the type assertion to ensure
+	// interface conformance
+	endBrace := structIndex + strings.Index(source[structIndex:], "}\n") + 2
+	source = source[:endBrace] +
+		fmt.Sprintf(
+			"\nvar _ %v.%vServer = (*Mock%vServer)(nil)\n\n",
+			strings.ToLower(serviceName),
+			serviceName,
+			serviceName,
+		) +
+		source[endBrace:]
+
+	// Format and write
+	if b, err := format.Source([]byte(source)); err != nil {
+		return fmt.Errorf("failed formatting: %w", err)
+	} else if err := os.WriteFile(os.Args[2], b, 0644); err != nil {
+		return fmt.Errorf("failed writing: %w", err)
+	}
+	return nil
+}

--- a/operatorservicemock/v1/service_grpc.pb.mock.go
+++ b/operatorservicemock/v1/service_grpc.pb.mock.go
@@ -300,9 +300,12 @@ func (mr *MockOperatorServiceClientMockRecorder) UpdateNexusEndpoint(ctx, in int
 
 // MockOperatorServiceServer is a mock of OperatorServiceServer interface.
 type MockOperatorServiceServer struct {
+	operatorservice.UnimplementedOperatorServiceServer
 	ctrl     *gomock.Controller
 	recorder *MockOperatorServiceServerMockRecorder
 }
+
+var _ operatorservice.OperatorServiceServer = (*MockOperatorServiceServer)(nil)
 
 // MockOperatorServiceServerMockRecorder is the mock recorder for MockOperatorServiceServer.
 type MockOperatorServiceServerMockRecorder struct {

--- a/workflowservicemock/v1/service_grpc.pb.mock.go
+++ b/workflowservicemock/v1/service_grpc.pb.mock.go
@@ -1360,9 +1360,12 @@ func (mr *MockWorkflowServiceClientMockRecorder) UpdateWorkflowExecution(ctx, in
 
 // MockWorkflowServiceServer is a mock of WorkflowServiceServer interface.
 type MockWorkflowServiceServer struct {
+	workflowservice.UnimplementedWorkflowServiceServer
 	ctrl     *gomock.Controller
 	recorder *MockWorkflowServiceServerMockRecorder
 }
+
+var _ workflowservice.WorkflowServiceServer = (*MockWorkflowServiceServer)(nil)
 
 // MockWorkflowServiceServerMockRecorder is the mock recorder for MockWorkflowServiceServer.
 type MockWorkflowServiceServerMockRecorder struct {


### PR DESCRIPTION
**What changed?**

Mocks were generated for older gRPC versions that didn't have the requirement to embed the unimplemented server as they do now. So we make sure this properly does embed this unimplemented server there and assert we conform to the interface.

I do not believe this should be considered a 💥 backwards compat break because others embeds of this should still work.

Closes https://github.com/temporalio/sdk-go/issues/1628