### PR TITLE
Fix for protogen cmd

### DIFF
--- a/cmd/protogen/main.go
+++ b/cmd/protogen/main.go
@@ -23,6 +23,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -119,9 +120,12 @@ func findEnums(ctx context.Context, cfg genConfig) ([]string, []string, error) {
 		if err != nil {
 			return err
 		}
-		matches := enumRgx.FindAllStringSubmatch(string(bs), -1)
-		for i := 0; i < len(matches); i++ {
-			enums = append(enums, matches[i][1])
+		scanner := bufio.NewScanner(bytes.NewReader(bs))
+		for scanner.Scan() {
+			matches := enumRgx.FindAllStringSubmatch(scanner.Text(), -1)
+			for i := 0; i < len(matches); i++ {
+				enums = append(enums, matches[i][1])
+			}
 		}
 		return nil
 	}
@@ -155,7 +159,7 @@ func runProtoc(ctx context.Context, cfg genConfig, protoDirs []string) error {
 		for _, plugin := range cfg.plugins {
 			args = append(args, fmt.Sprintf("--%s", plugin))
 		}
-		files, err := filepath.Glob(filepath.Join(dir, "*"))
+		files, err := filepath.Glob(filepath.Join(dir, "*.proto"))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
A couple of fixes for the `protogen` cmd.

- When looking for proto files ignore directories.
- Fix how regex is used when looking up enums.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Ran `make proto` and verified that there was no diff generated.

