### PR TITLE
[GHA][check-sdk-compat] Set staticcheck config to ignore deprecated symbols check

### DIFF
--- a/.github/workflows/check-sdk-compat.yml
+++ b/.github/workflows/check-sdk-compat.yml
@@ -67,6 +67,10 @@ jobs:
             cd -
           done
 
+      # staticcheck config to ignore deprecated symbols (SA1019); other values are part of default config
+      - name: Staticcheck config
+        run: echo 'checks = ["all", "-SA9003", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022", "-ST1023", "-SA1019"]' > staticcheck.conf
+
       - name: Run check
         run: go run . check
         working-directory: ./internal/cmd/build


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Set staticcheck config to ignore deprecated symbols check


<!-- Tell your future self why have you made these changes -->
**Why?**
API might introduce deprecated functions, and it should block this workflow for releasing the aPI.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Running the workflow without this change fails, and with this change passes when the API introduces deprecated functions.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

