### PR TITLE
Add support for parsing and testing repeated any fields

### DIFF
--- a/cmd/proxygenerator/interceptor.go
+++ b/cmd/proxygenerator/interceptor.go
@@ -329,6 +329,12 @@ func visitPayloads(
 			if err != nil {
 				return err
 			}
+		case []*anypb.Any:
+			for _, x := range o {
+				if err := visitPayloads(ctx, options, parent, x); err != nil {
+					return err
+				}
+			}
 {{range $type, $record := .PayloadTypes}}
 		{{if $record.Slice}}
 			case []{{$type}}:
@@ -395,6 +401,12 @@ func visitFailures(ctx *VisitFailuresContext, options *VisitFailuresOptions, obj
 				ctx.Parent = nil
 				if err != nil {
 					return err
+				}
+			case []*anypb.Any:
+				for _, x := range o {
+					if err := visitFailures(ctx, options, x); err != nil {
+						return err
+					}
 				}
 {{range $type, $record := .FailureTypes}}
 		{{if $record.Slice}}

--- a/proxy/interceptor.go
+++ b/proxy/interceptor.go
@@ -327,6 +327,12 @@ func visitPayloads(
 			if err != nil {
 				return err
 			}
+		case []*anypb.Any:
+			for _, x := range o {
+				if err := visitPayloads(ctx, options, parent, x); err != nil {
+					return err
+				}
+			}
 
 		case *batch.BatchOperationSignal:
 
@@ -2946,6 +2952,12 @@ func visitFailures(ctx *VisitFailuresContext, options *VisitFailuresOptions, obj
 			ctx.Parent = nil
 			if err != nil {
 				return err
+			}
+		case []*anypb.Any:
+			for _, x := range o {
+				if err := visitFailures(ctx, options, x); err != nil {
+					return err
+				}
 			}
 
 		case []*command.Command:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added support for payload and failure visitor to visit repeated Any fields.

Closes https://github.com/temporalio/sdk-go/issues/1864

<!-- Tell your future self why have you made these changes -->
**Why?**
Scenario we want to support

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added unit tests


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
entire payload/failure visitor breaks?
