### PR TITLE
Support visiting repeated Payload

### DIFF
--- a/cmd/proxygenerator/interceptor.go
+++ b/cmd/proxygenerator/interceptor.go
@@ -80,6 +80,9 @@ type VisitPayloadsOptions struct {
 }
 
 // VisitPayloads calls the options.Visitor function for every Payload proto within msg.
+//
+// Note: Directly visiting *common.Payload is not supported. Payloads must be passed through
+// a parent proto.
 func VisitPayloads(ctx context.Context, msg proto.Message, options VisitPayloadsOptions) error {
 	visitCtx := VisitPayloadsContext{Context: ctx, Parent: msg}
 
@@ -313,6 +316,14 @@ func visitPayloads(
 				for _, x := range o {
 					if err := visitPayloads(ctx, options, parent, x); err != nil {
 						return err
+					}
+				}
+			case []*common.Payload:
+				for ix, x := range o {
+					if nx, err := visitPayload(ctx, options, parent, x); err != nil {
+						return err
+					} else {
+						o[ix] = nx
 					}
 				}
 		case *anypb.Any:

--- a/proxy/interceptor.go
+++ b/proxy/interceptor.go
@@ -74,6 +74,9 @@ type VisitPayloadsOptions struct {
 }
 
 // VisitPayloads calls the options.Visitor function for every Payload proto within msg.
+//
+// Note: Directly visiting *common.Payload is not supported. Payloads must be passed through
+// a parent proto.
 func VisitPayloads(ctx context.Context, msg proto.Message, options VisitPayloadsOptions) error {
 	visitCtx := VisitPayloadsContext{Context: ctx, Parent: msg}
 
@@ -311,6 +314,14 @@ func visitPayloads(
 			for _, x := range o {
 				if err := visitPayloads(ctx, options, parent, x); err != nil {
 					return err
+				}
+			}
+		case []*common.Payload:
+			for ix, x := range o {
+				if nx, err := visitPayload(ctx, options, parent, x); err != nil {
+					return err
+				} else {
+					o[ix] = nx
 				}
 			}
 		case *anypb.Any:

--- a/proxy/interceptor_test.go
+++ b/proxy/interceptor_test.go
@@ -29,7 +29,6 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"slices"
 	"strings"
 	"testing"
 	"time"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added support for repeated payload.

Also added a note in the `VisitPayloads` godoc mentioning how we don't support directly visiting payloads (see https://github.com/temporalio/api-go/pull/202#discussion_r1920352920 for context).

Closes https://github.com/temporalio/sdk-go/issues/1862 and can probably close https://github.com/temporalio/sdk-go/issues/1862 as well, now that the godoc mentions this scenario.

<!-- Tell your future self why have you made these changes -->
**Why?**
Support an edge case scenario, only [AggregationGroup](https://github.com/temporalio/api/blob/9156239c8272003b6f228951602ca2b130a55876/temporal/api/workflowservice/v1/request_response.proto#L938) today uses this.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added tests


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

