### PR TITLE
Add "Aborted" servicerror

### DIFF
--- a/serviceerror/aborted.go
+++ b/serviceerror/aborted.go
@@ -1,0 +1,49 @@
+package serviceerror
+
+import (
+	"fmt"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type (
+	// Aborted represents an aborted error.
+	Aborted struct {
+		Message string
+		st      *status.Status
+	}
+)
+
+// NewAborted returns new Aborted error.
+func NewAborted(message string) error {
+	return &Aborted{
+		Message: message,
+	}
+}
+
+// NewAbortedf returns new Aborted error with formatted message.
+func NewAbortedf(format string, args ...any) error {
+	return &Aborted{
+		Message: fmt.Sprintf(format, args...),
+	}
+}
+
+// Error returns string message.
+func (e *Aborted) Error() string {
+	return e.Message
+}
+
+func (e *Aborted) Status() *status.Status {
+	if e.st != nil {
+		return e.st
+	}
+	return status.New(codes.Aborted, e.Message)
+}
+
+func newAborted(st *status.Status) error {
+	return &Aborted{
+		Message: st.Message(),
+		st:      st,
+	}
+}

--- a/serviceerror/convert.go
+++ b/serviceerror/convert.go
@@ -94,7 +94,7 @@ func FromStatus(st *status.Status) error {
 		case *failure.MultiOperationExecutionAborted:
 			return newMultiOperationAborted(st)
 		default:
-			// fall through to st.Err()
+			return newAborted(st)
 		}
 	case codes.Internal:
 		switch errDetails := errDetails.(type) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Added `Aborted` serviceerror.

<!-- Tell your future self why have you made these changes -->
**Why?**

There's a need to return an `Aborted` serviceerror from the server.

Given that we these serviceerror types for each status code, it seems like the right thing to add this here.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

