### PR TITLE
Fix proto generation for new subdirectories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ go-grpc: clean .go-helpers-installed $(PROTO_OUT)
 		-p grpc-gateway_out=allow_patch_feature=false,$(PROTO_PATHS) \
 		-p go-helpers_out=$(PROTO_PATHS)
 
-	mv -f $(PROTO_OUT)/temporal/api/* $(PROTO_OUT) && rm -rf $(PROTO_OUT)/temporal
+	cp -rf $(PROTO_OUT)/temporal/api/* $(PROTO_OUT) && rm -rf $(PROTO_OUT)/temporal
 
 http-api-docs: go-grpc
 	go run cmd/encode-openapi-spec/main.go \

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ go-grpc: clean .go-helpers-installed $(PROTO_OUT)
 		-p grpc-gateway_out=allow_patch_feature=false,$(PROTO_PATHS) \
 		-p go-helpers_out=$(PROTO_PATHS)
 
+	# cp is safer than mv because mv cannot merge into existing directories
 	cp -rf $(PROTO_OUT)/temporal/api/* $(PROTO_OUT) && rm -rf $(PROTO_OUT)/temporal
 
 http-api-docs: go-grpc


### PR DESCRIPTION
## What
Replace `mv -f` with `cp -rf` when flattening generated proto output, so new subdirectories (e.g. `nexusservices`) don't cause the build to fail.

## Why
`mv` cannot merge directories — when a new proto subdirectory is added to the api repo, `mv` fails with "cannot overwrite: Directory not empty". This is what's breaking the Update Proto workflow.

Example error:
```
Submodule path 'proto/api': checked out '67150b14e0509210bf250960bd3278a4509e091c'
Deleting generated go files...
Installing protoc plugin
Compile for go-gRPC...
mv: cannot overwrite './nexusservices': Directory not empty
make: *** [Makefile:56: go-grpc] Error 1
Error: Process completed with exit code 2.
```

## How did you test it?

Triggered a test run and it succeeded.
https://github.com/temporalio/api-go/actions/runs/24223347639

```
  gh workflow run update-proto.yml --repo temporalio/api-go --ref kannan/fix-makefile-mv \
    -f branch=kannan/fix-makefile-mv \
    -f commit_author="rkannan82" \
    -f commit_author_email="kannan@temporal.io" \
    -f commit_message="Test: verify proto generation with mv fix"
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)