### PR TITLE
Fix issue with nested anon structs in source code

### DIFF
--- a/cmd/mockgen-fix/main.go
+++ b/cmd/mockgen-fix/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"go/format"
 	"log"
@@ -8,28 +9,45 @@ import (
 	"strings"
 )
 
+// Print the code being modified to allow debugging any formatting-related problems.
+// e.g. $ go run ./cmd/mockgen-fix --verbose Service service_grpc.pb.mock.go
+var verbose = flag.Bool("verbose", false, "Print the results of the mockgen fix")
+
+// This code fixes the generated mock service server code to properly embed
+// the necessary unimplemented struct and add the interface assertion.
 func main() {
-	if err := run(); err != nil {
+	// Parse flags and args.
+	flag.Parse()
+
+	if flag.NArg() != 2 {
+		fmt.Println("Usage: mockgen-fix [service] [filename]")
+		fmt.Println("Error: No service or filename provided.")
+	}
+	service := flag.Arg(0)
+	filename := flag.Arg(1)
+
+	if err := run(service, filename); err != nil {
 		log.Fatal(err)
 	}
 }
 
-func run() error {
-	// This code fixes the generated mock service server code to properly embed
-	// the necessary unimplemented struct and add the interface assertion
+func run(serviceName, filename string) error {
 
-	if len(os.Args) != 3 {
-		return fmt.Errorf("must provide service name and code filename as arguments")
-	}
 	// Read file
-	b, err := os.ReadFile(os.Args[2])
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		return fmt.Errorf("unable to read file: %w", err)
 	}
-	source := string(b)
-	serviceName := os.Args[1]
 
-	// Find the first "Server struct {" location
+	source := string(b)
+	if *verbose {
+		fmt.Println("Source Mockgen Code")
+		fmt.Println("===================")
+		printSourceFile(source)
+		fmt.Println()
+	}
+
+	// Find the first "Server struct {" location.
 	toFind := fmt.Sprintf("Mock%vServer struct {\n", serviceName)
 	structIndex := strings.Index(source, toFind)
 	if structIndex < 0 || strings.LastIndex(source, toFind) != structIndex {
@@ -37,14 +55,14 @@ func run() error {
 	}
 	structIndex += len(toFind)
 
-	// At the first newline we need to embed the unimplemented server
+	// At the first newline we need to embed the unimplemented server.
 	source = source[:structIndex] +
 		fmt.Sprintf("\t%v.Unimplemented%vServer\n", strings.ToLower(serviceName), serviceName) +
 		source[structIndex:]
 
-	// After the closing brace, we need to add the type assertion to ensure
-	// interface conformance
-	endBrace := structIndex + strings.Index(source[structIndex:], "}\n") + 2
+	// After the closing brace ending the struct's definition, we need to add a type
+	// assertion to ensure interface conformance.
+	endBrace := structIndex + strings.Index(source[structIndex:], "\n}\n") + 2
 	source = source[:endBrace] +
 		fmt.Sprintf(
 			"\nvar _ %v.%vServer = (*Mock%vServer)(nil)\n\n",
@@ -55,10 +73,27 @@ func run() error {
 		source[endBrace:]
 
 	// Format and write
-	if b, err := format.Source([]byte(source)); err != nil {
+	formatted, err := format.Source([]byte(source))
+	if err != nil {
+		if *verbose {
+			fmt.Println("Resulting Code (pre-formatting)")
+			fmt.Println("===============================")
+			printSourceFile(source)
+			fmt.Println()
+		}
 		return fmt.Errorf("failed formatting: %w", err)
-	} else if err := os.WriteFile(os.Args[2], b, 0644); err != nil {
+	}
+
+	if err := os.WriteFile(filename, formatted, 0644); err != nil {
 		return fmt.Errorf("failed writing: %w", err)
 	}
 	return nil
+}
+
+// Prints the source file's contexts to STDOUT with line numbers.
+func printSourceFile(source string) {
+	lines := strings.Split(source, "\n")
+	for i, line := range lines {
+		fmt.Printf("%4d: %s\n", i+1, line)
+	}
 }


### PR DESCRIPTION
**What changed?**

- Fix an bug where `mockgen-fix` would fail to format updated source code if the mock struct contained a field with an anonymous struct type (`struct{}`).
- Wire up a new `--verbose` flag to print out the code being modified, to make it easier to debug errors during the formatting step.

**Why?**

I was unable to run `make proto` because the `mockgen-fix` step was failing with the following error:

```
2026/04/24 13:55:32 failed formatting: 292:1: expected '}', found 'var'
exit status 1
```

As it turns out, there is a minor bug in the implementation. The version of `mockgen` I have on my machine (`v0.6.0`) apparently emits the expected struct with a new field that causes the logic for finding the "end of the struct `}`".

```diff
  285: // MockOperatorServiceServer is a mock of OperatorServiceServer interface.
  286: type MockOperatorServiceServer struct {
  287: 	ctrl     *gomock.Controller
  288: 	recorder *MockOperatorServiceServerMockRecorder
+ 289: 	isgomock struct{}
  290: }
```

So the actual fix is just changing this line, ensuring that we find the first `}` character _at the start of the line_. (And not the last character of `isgomock struct{}`.)

```diff
- endBrace := structIndex + strings.Index(source[structIndex:], "}\n") + 2
+ endBrace := structIndex + strings.Index(source[structIndex:], "\n}\n") + 2
```

But this PR includes the additional refactorings I used to look into this.

**How did you test it?**

Just ran it locally. Now things work as expected.

**Potential risks**

If the proto compiler emits Go code where structs _don't_ end with their last `}` at the beginning of the line, then `mockgen-fix` will start failing in CI.

**BONUS: When did this break?!?**

I'm a little confused why I am running into problems here. After some quick searching:

> The isgomock struct{} field was added to the mockgen output in October 2024 as part of the v0.5.0 release of the uber-go/mock fork.
> This change was specifically introduced in Pull Request #204 to resolve a common issue where mocking the fmt.Stringer interface could lead to deadlocks or infinite recursion during test failures. 

So... could it be the case that everyone using `mockgen` is on a version from 10/2024? And I'm only hitting this because I just ran `go install go.uber.org/mock/mockgen@latest` this afternoon?

That is plausible, but doesn't sound right...
