### PR TITLE
Truncate service error message

### DIFF
--- a/serviceerror/convert.go
+++ b/serviceerror/convert.go
@@ -3,6 +3,7 @@ package serviceerror
 import (
 	"context"
 	"errors"
+	"unicode/utf8"
 
 	spb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
@@ -12,9 +13,23 @@ import (
 	"go.temporal.io/api/failure/v1"
 )
 
+const (
+	maxMessageLength       = 4000
+	truncatedMessageSuffix = "... <truncated>"
+)
+
 // ToStatus converts service error to gRPC Status.
 // If error is not a service error it returns status with code Unknown.
-func ToStatus(err error) *status.Status {
+func ToStatus(err error) (st *status.Status) {
+	defer func() {
+		if len(st.Message()) <= maxMessageLength {
+			return
+		}
+		spb := st.Proto()
+		spb.Message = truncateMessage(spb.Message)
+		st = status.FromProto(spb)
+	}()
+
 	if err == nil {
 		return status.New(codes.OK, "")
 	}
@@ -22,21 +37,23 @@ func ToStatus(err error) *status.Status {
 	if svcerr, ok := err.(ServiceError); ok {
 		return svcerr.Status()
 	}
+
+	errMsg := truncateMessage(err.Error())
 	// err does not implement ServiceError directly, but check if it wraps it.
 	// This path does more allocation so prefer to return a ServiceError directly if possible.
 	var svcerr ServiceError
 	if errors.As(err, &svcerr) {
 		s := svcerr.Status().Proto()
-		s.Message = err.Error() // don't lose the wrapped message
+		s.Message = errMsg // don't lose the wrapped message
 		return status.FromProto(s)
 	}
 
 	// Special case for context.DeadlineExceeded and context.Canceled because they can happen in unpredictable places.
 	if errors.Is(err, context.DeadlineExceeded) {
-		return status.New(codes.DeadlineExceeded, err.Error())
+		return status.New(codes.DeadlineExceeded, errMsg)
 	}
 	if errors.Is(err, context.Canceled) {
-		return status.New(codes.Canceled, err.Error())
+		return status.New(codes.Canceled, errMsg)
 	}
 
 	// Internal logic of status.Convert is:
@@ -185,4 +202,27 @@ func extractErrorDetails(st *status.Status) any {
 	}
 
 	return nil
+}
+
+// truncateUTF8 truncates s to no more than n _bytes_, and returns a valid utf-8 string as long
+// as the input is a valid utf-8 string.
+// Note that truncation pays attention to codepoints only! This may truncate in the middle of a
+// grapheme cluster.
+func truncateUTF8(s string, n int) string {
+	if len(s) <= n {
+		return s
+	} else if n <= 0 {
+		return ""
+	}
+	for n > 0 && !utf8.RuneStart(s[n]) {
+		n--
+	}
+	return s[:n]
+}
+
+func truncateMessage(s string) string {
+	if len(s) <= maxMessageLength {
+		return s
+	}
+	return truncateUTF8(s, maxMessageLength-len(truncatedMessageSuffix)) + truncatedMessageSuffix
 }

--- a/serviceerror/convert_test.go
+++ b/serviceerror/convert_test.go
@@ -1,8 +1,10 @@
 package serviceerror_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -189,6 +191,60 @@ func TestMultiOperationAborted(t *testing.T) {
 
 	reconstructedStatus := serviceerror.ToStatus(errFromStatus)
 	require.True(t, proto.Equal(st.Proto(), reconstructedStatus.Proto()))
+}
+
+func TestToStatus_TruncatesLongMessage(t *testing.T) {
+	longMsg := strings.Repeat("x", 5000)
+
+	t.Run("plain error", func(t *testing.T) {
+		err := errors.New(longMsg)
+		st := serviceerror.ToStatus(err)
+		require.LessOrEqual(t, len(st.Message()), 4000)
+		require.True(t, strings.HasSuffix(st.Message(), "... <truncated>"))
+		require.Equal(t, codes.Unknown, st.Code())
+	})
+
+	t.Run("service error with long message", func(t *testing.T) {
+		err := serviceerror.NewNotFound(longMsg)
+		st := serviceerror.ToStatus(err)
+		require.LessOrEqual(t, len(st.Message()), 4000)
+		require.True(t, strings.HasSuffix(st.Message(), "... <truncated>"))
+		require.Equal(t, codes.NotFound, st.Code())
+	})
+
+	t.Run("wrapped service error", func(t *testing.T) {
+		inner := &serviceerror.PermissionDenied{
+			Message: "denied",
+			Reason:  "test-reason",
+		}
+		err := fmt.Errorf("%s: %w", longMsg, inner)
+		st := serviceerror.ToStatus(err)
+		require.LessOrEqual(t, len(st.Message()), 4000)
+		require.True(t, strings.HasSuffix(st.Message(), "... <truncated>"))
+		require.Equal(t, codes.PermissionDenied, st.Code())
+	})
+
+	t.Run("deadline exceeded with long message", func(t *testing.T) {
+		err := fmt.Errorf("%s: %w", longMsg, context.DeadlineExceeded)
+		st := serviceerror.ToStatus(err)
+		require.LessOrEqual(t, len(st.Message()), 4000)
+		require.True(t, strings.HasSuffix(st.Message(), "... <truncated>"))
+		require.Equal(t, codes.DeadlineExceeded, st.Code())
+	})
+
+	t.Run("canceled with long message", func(t *testing.T) {
+		err := fmt.Errorf("%s: %w", longMsg, context.Canceled)
+		st := serviceerror.ToStatus(err)
+		require.LessOrEqual(t, len(st.Message()), 4000)
+		require.True(t, strings.HasSuffix(st.Message(), "... <truncated>"))
+		require.Equal(t, codes.Canceled, st.Code())
+	})
+
+	t.Run("short message not truncated", func(t *testing.T) {
+		err := errors.New("short error")
+		st := serviceerror.ToStatus(err)
+		require.Equal(t, "short error", st.Message())
+	})
 }
 
 func TestFromWrapped(t *testing.T) {

--- a/serviceerror/truncate_test.go
+++ b/serviceerror/truncate_test.go
@@ -1,0 +1,141 @@
+package serviceerror
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTruncateUTF8(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		n      int
+		expect string
+	}{
+		{
+			name:   "empty string",
+			input:  "",
+			n:      10,
+			expect: "",
+		},
+		{
+			name:   "n is zero",
+			input:  "hello",
+			n:      0,
+			expect: "",
+		},
+		{
+			name:   "n is negative",
+			input:  "hello",
+			n:      -1,
+			expect: "",
+		},
+		{
+			name:   "ascii shorter than n",
+			input:  "hello",
+			n:      10,
+			expect: "hello",
+		},
+		{
+			name:   "ascii equal to n",
+			input:  "hello",
+			n:      5,
+			expect: "hello",
+		},
+		{
+			name:   "ascii longer than n",
+			input:  "hello world",
+			n:      5,
+			expect: "hello",
+		},
+		{
+			name:   "multi-byte truncation at codepoint boundary",
+			input:  "abc\u00e9def",  // \u00e9 is 2 bytes (é)
+			n:      5,              // 'a','b','c' = 3 bytes, 'é' = 2 bytes = 5 bytes total
+			expect: "abc\u00e9",
+		},
+		{
+			name:   "multi-byte truncation in middle of codepoint",
+			input:  "abc\u00e9def",  // \u00e9 is 2 bytes
+			n:      4,              // 3 + 1 byte into é → backs up to 3
+			expect: "abc",
+		},
+		{
+			name:   "3-byte utf8 at boundary",
+			input:  "ab\u4e16\u754c", // 世界, each 3 bytes; total = 2+3+3 = 8
+			n:      5,                // 2 + 3 = 5 → clean cut after 世
+			expect: "ab\u4e16",
+		},
+		{
+			name:   "3-byte utf8 mid codepoint",
+			input:  "ab\u4e16\u754c",
+			n:      6,               // 2 + 3 + 1 byte into 界 → backs up to 5
+			expect: "ab\u4e16",
+		},
+		{
+			name:   "4-byte utf8 emoji",
+			input:  "hi\U0001F600ok", // 😀 is 4 bytes; total = 2+4+2 = 8
+			n:      3,               // 2 + 1 byte into 😀 → backs up to 2
+			expect: "hi",
+		},
+		{
+			name:   "4-byte utf8 emoji at boundary",
+			input:  "hi\U0001F600ok",
+			n:      6,              // 2 + 4 = 6 → clean cut after 😀
+			expect: "hi\U0001F600",
+		},
+		{
+			name:   "all multi-byte, n=1 backs up to empty",
+			input:  "\u00e9\u00e9", // each 2 bytes
+			n:      1,             // 1 byte into first é → backs up to 0
+			expect: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := truncateUTF8(tt.input, tt.n)
+			require.Equal(t, tt.expect, result)
+			require.True(t, utf8.ValidString(result), "result should be valid UTF-8")
+			require.LessOrEqual(t, len(result), max(tt.n, 0), "result byte length should not exceed n")
+		})
+	}
+}
+
+func TestTruncateMessage(t *testing.T) {
+	t.Run("short message unchanged", func(t *testing.T) {
+		msg := "short error message"
+		require.Equal(t, msg, truncateMessage(msg))
+	})
+
+	t.Run("exactly at limit unchanged", func(t *testing.T) {
+		msg := strings.Repeat("a", maxMessageLength)
+		require.Equal(t, msg, truncateMessage(msg))
+	})
+
+	t.Run("over limit is truncated with suffix", func(t *testing.T) {
+		msg := strings.Repeat("a", maxMessageLength+100)
+		result := truncateMessage(msg)
+		require.LessOrEqual(t, len(result), maxMessageLength)
+		require.True(t, strings.HasSuffix(result, truncatedMessageSuffix))
+	})
+
+	t.Run("one byte over limit is truncated", func(t *testing.T) {
+		msg := strings.Repeat("a", maxMessageLength+1)
+		result := truncateMessage(msg)
+		require.LessOrEqual(t, len(result), maxMessageLength)
+		require.True(t, strings.HasSuffix(result, truncatedMessageSuffix))
+	})
+
+	t.Run("multi-byte chars truncated cleanly", func(t *testing.T) {
+		// Fill with 3-byte UTF-8 characters (世 = 3 bytes each)
+		msg := strings.Repeat("\u4e16", maxMessageLength) // way over limit
+		result := truncateMessage(msg)
+		require.LessOrEqual(t, len(result), maxMessageLength)
+		require.True(t, strings.HasSuffix(result, truncatedMessageSuffix))
+		require.True(t, utf8.ValidString(result), "result should be valid UTF-8")
+	})
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Truncate service error messages when converting to gRPC status.

<!-- Tell your future self why have you made these changes -->
**Why?**
Prevent gRPC from returning `RST_STREAM` error when the error message is too long.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added new unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

