### PR TITLE
fix: non-constant format string in call error

### DIFF
--- a/cmd/protogen/main.go
+++ b/cmd/protogen/main.go
@@ -305,6 +305,6 @@ func main() {
 		outputDescriptorPath: outputDescriptorPath,
 	})
 	if err != nil {
-		fail(err.Error())
+		fail("%s", err)
 	}
 }


### PR DESCRIPTION
**What changed?**
Fix `go vet` issue from latest Go 1.25.10 which is automatically used because `setup-go` uses `check-latest: true`.

**Why?**
Breaks Update Proto action: https://github.com/temporalio/api-go/actions/runs/25744586768/job/75604162428

**How did you test it?**
Tested go vet locally

**Potential risks**
CI only
