### PR TITLE
Update pnpm steps to work on latest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ nexus-rpc-gen-install:
 	@printf $(COLOR) "Install nexus-rpc-gen from main..."
 	@rm -rf $(NEXUS_RPC_GEN_CACHE)
 	@git clone --depth 1 https://github.com/nexus-rpc/nexus-rpc-gen.git $(NEXUS_RPC_GEN_CACHE)
-	@cd $(NEXUS_RPC_GEN_CACHE)/src && pnpm install && pnpm run build
+	@cd $(NEXUS_RPC_GEN_CACHE)/src && pnpm install --ignore-scripts && pnpm run build
 	@chmod +x $(NEXUS_RPC_GEN_CACHE)/src/packages/nexus-rpc-gen/dist/index.js
 	@cd $(NEXUS_RPC_GEN_CACHE)/src/packages/nexus-rpc-gen && pnpm add --global .
 

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ nexus-rpc-gen-install:
 	@printf $(COLOR) "Install nexus-rpc-gen from main..."
 	@rm -rf $(NEXUS_RPC_GEN_CACHE)
 	@git clone --depth 1 https://github.com/nexus-rpc/nexus-rpc-gen.git $(NEXUS_RPC_GEN_CACHE)
-	@cd $(NEXUS_RPC_GEN_CACHE)/src && pnpm install --ignore-scripts && pnpm run build
+	@cd $(NEXUS_RPC_GEN_CACHE)/src && pnpm install && pnpm run build
 	@chmod +x $(NEXUS_RPC_GEN_CACHE)/src/packages/nexus-rpc-gen/dist/index.js
 	@cd $(NEXUS_RPC_GEN_CACHE)/src/packages/nexus-rpc-gen && pnpm add --global .
 

--- a/Makefile
+++ b/Makefile
@@ -130,9 +130,9 @@ nexus-rpc-gen-install:
 	@printf $(COLOR) "Install nexus-rpc-gen from main..."
 	@rm -rf $(NEXUS_RPC_GEN_CACHE)
 	@git clone --depth 1 https://github.com/nexus-rpc/nexus-rpc-gen.git $(NEXUS_RPC_GEN_CACHE)
-	@cd $(NEXUS_RPC_GEN_CACHE)/src && pnpm install && pnpm run build
+	@cd $(NEXUS_RPC_GEN_CACHE)/src && pnpm install --ignore-scripts && pnpm run build
 	@chmod +x $(NEXUS_RPC_GEN_CACHE)/src/packages/nexus-rpc-gen/dist/index.js
-	@cd $(NEXUS_RPC_GEN_CACHE)/src/packages/nexus-rpc-gen && pnpm link --global
+	@cd $(NEXUS_RPC_GEN_CACHE)/src/packages/nexus-rpc-gen && pnpm add --global .
 
 mockgen-install:
 	printf $(COLOR) "Install/update mockgen..."


### PR DESCRIPTION
**What changed?**

Updated the steps for the `make nexus-rpc-gen-install` step.


**Why?**

If you are running the latest version of `pnpm` (e.g. `11.1.1` via Homebrew), the steps will fail. There was a breaking change for the `pnpm link` command in version 11:

https://pnpm.io/cli/link
> pnpm link --global has been removed. To register a local package's bins globally, use pnpm add -g . instead.
>
> pnpm link with no arguments has been removed. Always pass an explicit path.


**How did you test it?**

Ran `make nexus-rpc-gen-install` and `make proto`, both were successful.


**Potential risks**

The updated steps don't work on lower versions of `pnpm`, e.g. v10.x that is probably what other people on the team have installed today.

(To verify, please patch this and let me know before I merge 😄...)

