### PR TITLE
Add pnpm to api -> api-go sync Github Actions runner

### DIFF
--- a/.github/workflows/update-proto.yml
+++ b/.github/workflows/update-proto.yml
@@ -51,6 +51,10 @@ jobs:
         with:
           version: "3.x"
 
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
       - name: Re-build proto
         run: |
           make install update-proto test


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

[`pnpm` was recently added to the Makefile target for `nexus-rpc-gen-install`](https://github.com/temporalio/api-go/blob/master/Makefile#L129-L135), which runs as part of the GHA that syncs protos from `api` to `api-go` via [this command: `make install update-proto test`](https://github.com/temporalio/api-go/blob/master/.github/workflows/update-proto.yml#L56)

We also need to add `pnpm` to here, otherwise the GHA runner will fail, i.e., https://github.com/temporalio/api-go/actions/runs/26116994851/job/76808739969:

```
Run make install update-proto test
  make install update-proto test
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
Install nexus-rpc-gen from main...
Cloning into '/home/runner/.cache/nexus-rpc-gen'...
/bin/sh: 1: pnpm: not found
make: *** [Makefile:133: nexus-rpc-gen-install] Error 127
```

<!-- Tell your future self why have you made these changes -->
**Why?**

So GHA runner works.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Please advise