### PR TITLE
Add pnpm to api -> api-go sync Github Actions runner

### DIFF
--- a/.github/workflows/update-proto.yml
+++ b/.github/workflows/update-proto.yml
@@ -51,6 +51,19 @@ jobs:
         with:
           version: "3.x"
 
+      # Needed for pnpm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # For nexus-rpc-gen-install
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      # Add pnpm directory to PATH for runner
+      - run: echo "$PNPM_HOME/bin" >> $GITHUB_PATH
+
       - name: Re-build proto
         run: |
           make install update-proto test


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

[`pnpm` was recently added to the Makefile target for `nexus-rpc-gen-install`](https://github.com/temporalio/api-go/blob/master/Makefile#L129-L135), which runs as part of the GHA that syncs protos from `api` to `api-go` via [this command: `make install update-proto test`](https://github.com/temporalio/api-go/blob/master/.github/workflows/update-proto.yml#L56)

We also need to add `pnpm` to here, otherwise the GHA runner will fail, i.e., https://github.com/temporalio/api-go/actions/runs/26116994851/job/76808739969:

```
Run make install update-proto test
  make install update-proto test
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
Install nexus-rpc-gen from main...
Cloning into '/home/runner/.cache/nexus-rpc-gen'...
/bin/sh: 1: pnpm: not found
make: *** [Makefile:133: nexus-rpc-gen-install] Error 127
```

<!-- Tell your future self why have you made these changes -->
**Why?**

So GHA runner works.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Manual GHA kickoff from my branch by running:

```
$ gh workflow run update-proto.yml \
    --repo temporalio/api-go \
    --ref long-nt-tran/add-pnpm-gha-runner \
    --field branch=long-nt-tran/add-pnpm-gha-runner \
    --field commit_author="long-nt-tran" \
    --field commit_author_email="long.tran@temporal.io" \
    --field commit_message="Manual run to verify pnpm setup in GHA works"
✓ Created workflow_dispatch event for update-proto.yml at long-nt-tran/add-pnpm-gha-runner
https://github.com/temporalio/api-go/actions/runs/26121571272

To see the created workflow run, try: gh run view 26121571272
To see runs for this workflow, try: gh run list --workflow="update-proto.yml"
```

GHA run passes: https://github.com/temporalio/api-go/actions/runs/26121571272
It correctly synced https://github.com/temporalio/api/pull/742/ to `api-go` (on this branch): https://github.com/temporalio/api-go/commit/2150dd508c913e2457d01a0151be46a64cde213c#diff-4253e2d69d45111060b6d9fb4cdc22f1ad5942e4836eabf57b6845b9e319e7c7
