### PR TITLE
Disable gomod version-bump PRs, keep security alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0
     cooldown:
       default-days: 14
 
@@ -11,6 +12,7 @@ updates:
     directory: "/build"
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0
     cooldown:
       default-days: 14
 
@@ -18,6 +20,7 @@ updates:
     directory: "/cmd/proxygenerator"
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0
     cooldown:
       default-days: 14
 


### PR DESCRIPTION
## What was changed

Set `open-pull-requests-limit: 0` for `gomod` in Dependabot config.

## Why?

After discussion with @yuandrew, we agreed to suppress automatic version update PRs while still allowing Dependabot security PRs through. Go dependencies are upgraded on-demand, not automatically.
