### PR TITLE
CI: Remove `master` branch trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ on:
   pull_request:
   push:
     branches:
-      - master
       - main
 
 jobs:


### PR DESCRIPTION
**What changed?**
Remove `master` branch trigger

**Why?**
`master` got renamed to `main`


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

