### PR TITLE
feat: trigger CLI code generation on API changes

### DIFF
--- a/.github/workflows/trigger-cli-update.yml
+++ b/.github/workflows/trigger-cli-update.yml
@@ -1,0 +1,70 @@
+# Mirrors temporalio/api's "Trigger api-go Update" workflow, retargeted at the CLI:
+# on every merge to api-go's main, dispatches the CLI's
+# update-system-nexus-operations.yml, which bumps go.temporal.io/api, runs
+# `make gen`, and opens a PR if the system Nexus operations changed.
+
+name: 'Trigger CLI Update'
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch in CLI repo to trigger system Nexus update (default: main)"
+        required: true
+        default: main
+
+jobs:
+  notify:
+    name: 'Trigger CLI Update'
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
+          private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: cli # generate a token with permissions to trigger GHA in cli repo
+
+      - name: Dispatch CLI GitHub Action
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+          EVENT_PUSH_BRANCH: ${{ github.event.ref }}
+          EVENT_PUSH_COMMIT_AUTHOR: ${{ github.event.head_commit.author.name }}
+          EVENT_PUSH_COMMIT_AUTHOR_EMAIL: ${{ github.event.head_commit.author.email }}
+          EVENT_PUSH_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          EVENT_WF_DISPATCH_BRANCH: ${{ github.event.inputs.branch }}
+        run: |
+          case "${{ github.event_name }}" in
+            "push")
+              BRANCH="${EVENT_PUSH_BRANCH#refs/heads/}"
+              COMMIT_AUTHOR="${EVENT_PUSH_COMMIT_AUTHOR}"
+              COMMIT_AUTHOR_EMAIL="${EVENT_PUSH_COMMIT_AUTHOR_EMAIL}"
+              COMMIT_MESSAGE="${EVENT_PUSH_COMMIT_MESSAGE}"
+              ;;
+
+            "workflow_dispatch")
+              BRANCH="${EVENT_WF_DISPATCH_BRANCH}"
+              COMMIT_AUTHOR="Temporal Data"
+              COMMIT_AUTHOR_EMAIL="commander-data@temporal.io"
+              COMMIT_MESSAGE="Update System Nexus Operations"
+              ;;
+          esac
+
+          # The CLI receiver always bases the bump on its own main, so target main there
+          # regardless of the api-go branch name.
+          gh workflow run update-system-nexus-operations.yml -R https://github.com/temporalio/cli \
+            -r main \
+            -f branch=main \
+            -f commit_author="${COMMIT_AUTHOR}" \
+            -f commit_author_email="${COMMIT_AUTHOR_EMAIL}" \
+            -f commit_message="${COMMIT_MESSAGE}"


### PR DESCRIPTION
**What changed?**
Add CI job to trigger temporalio/cli repo to regenerate system nexus operations when `api-go` has merges to main.

**Why?**
https://github.com/temporalio/cli/pull/1090 - CLI PR to automatically generate the system nexus operations map for use unwrapping operations.

**How did you test it?**
Will be tested after merging, cannot test these changes until after the CLI PR merges and this PR merges.

**Potential risks**
Minimal
