### PR TITLE
VLN-1538: remediate checkout-below-v7

### DIFF
--- a/.github/workflows/check-sdk-compat.yml
+++ b/.github/workflows/check-sdk-compat.yml
@@ -46,7 +46,7 @@ jobs:
           echo "API_REF=$API_REF" | tee -a "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: temporalio/sdk-go
           ref: ${{ steps.inputs.outputs.SDK_REF }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Print build information
         run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF"'
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
       - name: Install protoc

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -40,7 +40,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: temporalio/api-go
           ref: ${{ inputs.ref }}

--- a/.github/workflows/update-proto.yml
+++ b/.github/workflows/update-proto.yml
@@ -35,7 +35,7 @@ jobs:
           private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ steps.generate_token.outputs.token }}
           persist-credentials: true


### PR DESCRIPTION
> 🏕️ This pull request was created by [camper](https://github.com/temporalio/camper), an automated security campaign tool.

## Finding

<table>
  <tr><td><strong>Rule</strong></td><td><code>checkout-below-v7</code></td></tr>
  <tr><td><strong>Severity</strong></td><td>MEDIUM</td></tr>
  <tr><td><strong>Repository</strong></td><td><code>temporalio/api-go</code></td></tr>
  <tr><td><strong>Ticket</strong></td><td><a href="https://temporalio.atlassian.net/browse/VLN-1538">VLN-1538</a></td></tr>
</table>

## Summary

- `.github/workflows/check-sdk-compat.yml`: Pinned `actions/checkout` to `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0`.
- `.github/workflows/ci.yml`: Pinned `actions/checkout` to `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0`.
- `.github/workflows/create-release.yml`: Pinned `actions/checkout` to `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0`.
- `.github/workflows/update-proto.yml`: Pinned `actions/checkout` to `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0`.

## Instructions

- **Approve** to merge this fix
- **Request changes** to trigger a new remediation attempt
- `/camper rebase` — rebase onto the base branch
- `/camper close` — close this PR without merging
- `/camper retry` — regenerate the fix from scratch against the current base